### PR TITLE
feat(routes): add support for CORS preflight requests in API routes

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -1,7 +1,6 @@
 <?php
 
 use CodeIgniter\Router\RouteCollection;
-use Config\Services;
 
 /**
  * @var \CodeIgniter\Router\RouteCollection $routes
@@ -28,4 +27,27 @@ $routes->group('api/v2', ['filter' => 'cors'], function (RouteCollection $routes
 
     // Redefinição de senha
     $routes->post('reset', 'AuthController::reset');
+
+    // Adicionando suporte para OPTIONS (Preflight Requests)
+    $routes->options('register', static function () {
+        return response()->setStatusCode(204); // No Content
+    });
+    $routes->options('login', static function () {
+        return response()->setStatusCode(204);
+    });
+    $routes->options('logout', static function () {
+        return response()->setStatusCode(204);
+    });
+    $routes->options('verify', static function () {
+        return response()->setStatusCode(204);
+    });
+    $routes->options('recovery', static function () {
+        return response()->setStatusCode(204);
+    });
+    $routes->options('reset-confirm/(:segment)', static function () {
+        return response()->setStatusCode(204);
+    });
+    $routes->options('reset', static function () {
+        return response()->setStatusCode(204);
+    });
 });

--- a/app/Filters/CorsFilter.php
+++ b/app/Filters/CorsFilter.php
@@ -11,18 +11,17 @@ class CorsFilter implements FilterInterface
     public function before(RequestInterface $request, $arguments = null)
     {
         header("Access-Control-Allow-Origin: *");
-        header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
-        header("Access-Control-Allow-Headers: Content-Type, Authorization");
+        header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, PATCH, DELETE");
+        header("Access-Control-Allow-Headers: Authorization, Content-Type");
 
-        // Permite que a solicitação `OPTIONS` continue sem erros
-        if ($request->getMethod() == 'options') {
-            header('HTTP/1.1 200 OK');
+        if ($request->getMethod() === 'options') {
+            header("HTTP/1.1 204 No Content");
             exit;
         }
     }
 
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {
-        // Código adicional, se necessário
+        // Não é necessário modificar a resposta no momento
     }
 }


### PR DESCRIPTION
- Added explicit OPTIONS routes for CORS preflight requests in the 'api/v2' group.
- Ensured each API route (register, login, logout, verify, recovery, reset-confirm, reset) has a corresponding OPTIONS route to handle preflight checks.
- Configured OPTIONS routes to return HTTP 204 (No Content) responses.
- Improved compatibility with browsers by enabling proper CORS handling.